### PR TITLE
Make sure we checkout a branch rather than a file

### DIFF
--- a/gitwrapperlib/gitwrapperlib.py
+++ b/gitwrapperlib/gitwrapperlib.py
@@ -187,7 +187,7 @@ class Git:
 
     def switch_branch(self, name):
         """Switches to a branch."""
-        self._git.checkout(name)
+        self._git.checkout(name, "--")
 
     def list_tags(self):
         """Lists existing tags."""


### PR DESCRIPTION
switch_branch can fail if branch names overlap with filenames in the repository.
Adding an explicit '--' instructs git to parse the argument as a branch name.

I've got the following code:
`git.switch_branch(mr_branch)`

Which triggers the following error when there is an overlap in branch and filenames:

```
  RAN: /usr/bin/git checkout acceptance
  STDOUT:
  STDERR:
fatal: 'acceptance' could be both a local file and a tracking branch.
Please use -- (and optionally --no-guess) to disambiguate
```